### PR TITLE
Add general.yaml config loader

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,8 @@
+# Options
+
+## General
+
+### `listener`
+
+Which listener to use. It can be `mic` or `text`
+

--- a/config/general.yaml
+++ b/config/general.yaml
@@ -1,1 +1,1 @@
-hello: world
+listener: text

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/METIL-HoloAI/HoloTable-Middleware
 
 go 1.23.4
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cmd/cli/main.go
+++ b/internal/cmd/cli/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	
+
 	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/configloader"
 )
 
@@ -17,9 +17,9 @@ func main() {
 
 	// Check how user wants to listen for input
 	// and start that listener
-	if(settings.Listener == "cli") {
+	if settings.Listener == "cli" {
 		fmt.Println("CLI Listener")
-	} else if(settings.Listener == "text") {
+	} else if settings.Listener == "text" {
 		fmt.Println("Text Listener")
 	} else {
 		fmt.Println("Invalid listener option in general.yaml")

--- a/internal/cmd/cli/main.go
+++ b/internal/cmd/cli/main.go
@@ -2,14 +2,27 @@ package main
 
 import (
 	"fmt"
+	
+	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/configloader"
 )
 
 func main() {
-	fmt.Println("Hello, World!")
-	fmt.Println("Hello World2!")
-
 	// Load yaml
+	settings, err := configloader.LoadGeneral()
+	if err != nil {
+		fmt.Println("Error loading general settings")
+		fmt.Println(err)
+		return
+	}
 
 	// Check how user wants to listen for input
 	// and start that listener
+	if(settings.Listener == "cli") {
+		fmt.Println("CLI Listener")
+	} else if(settings.Listener == "text") {
+		fmt.Println("Text Listener")
+	} else {
+		fmt.Println("Invalid listener option in general.yaml")
+	}
+
 }

--- a/internal/cmd/cli/main.go
+++ b/internal/cmd/cli/main.go
@@ -17,8 +17,8 @@ func main() {
 
 	// Check how user wants to listen for input
 	// and start that listener
-	if settings.Listener == "cli" {
-		fmt.Println("CLI Listener")
+	if settings.Listener == "mic" {
+		fmt.Println("Microphone Listener")
 	} else if settings.Listener == "text" {
 		fmt.Println("Text Listener")
 	} else {

--- a/internal/cmd/cli/main.go
+++ b/internal/cmd/cli/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	// Load yaml
-	settings, err := configloader.LoadGeneral()
+	settings, err := configloader.GetGeneral()
 	if err != nil {
 		fmt.Println("Error loading general settings")
 		fmt.Println(err)

--- a/internal/configloader/general.go
+++ b/internal/configloader/general.go
@@ -1,0 +1,23 @@
+package configloader
+
+import (
+	"os"
+
+	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/configloader/structs"
+	"gopkg.in/yaml.v3"
+)
+
+func LoadGeneral() (structs.GeneralSettings, error) {
+
+	file, err := os.ReadFile("config/general.yaml")
+	if err != nil {
+		return structs.GeneralSettings{}, err
+	}
+
+	var settings structs.GeneralSettings
+	if err := yaml.Unmarshal(file, &settings); err != nil {
+		return structs.GeneralSettings{}, err
+	}
+
+	return settings, nil
+}

--- a/internal/configloader/loader.go
+++ b/internal/configloader/loader.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func LoadGeneral() (structs.GeneralSettings, error) {
+func GetGeneral() (structs.GeneralSettings, error) {
 
 	file, err := os.ReadFile("config/general.yaml")
 	if err != nil {

--- a/internal/configloader/structs/general_struct.go
+++ b/internal/configloader/structs/general_struct.go
@@ -1,0 +1,7 @@
+package structs
+
+import ()
+
+type GeneralSettings struct {
+	Listener string
+}


### PR DESCRIPTION
This is only a baseline for what will eventually become the full general.yaml config loader. This serves as a good frame of reference for future iterations as well as future config loaders.