### PR TITLE
Add error check for input

### DIFF
--- a/internal/listeners/text.go
+++ b/internal/listeners/text.go
@@ -8,7 +8,10 @@ func StartTextListener() {
 		fmt.Println("(q)uit, (r)eload yaml")
 
 		var input string
-		fmt.Scanln(&input)
+		_, err := fmt.Scanln(&input)
+		if err != nil {
+			fmt.Println(err)
+		}
 
 		if input == "q" {
 			return


### PR DESCRIPTION
Fix error from linter on main where error is never checked for when scanning in input on the text listener