### PR TITLE
Database functions

### DIFF
--- a/cmd/holoai/main.go
+++ b/cmd/holoai/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/config"
 	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/database"
@@ -12,7 +15,17 @@ import (
 func main() {
 	config.LoadYaml()
 
-	database.Init()
+	if err := os.MkdirAll(config.General.DataDir, os.ModePerm); err != nil {
+		log.Fatal("Failed to create data directory:", err)
+	}
+
+	db, err := sql.Open("sqlite3", config.General.DataDir+"database.db?_mode=shared&_journal_mode=WAL")
+	if err != nil {
+		log.Fatal("Failed to open database:", err)
+	}
+	defer db.Close()
+
+	database.Init(db)
 
 	// Check how user wants to listen for input
 	// and start that listener

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -24,9 +24,6 @@ func Init() {
 	}
 	defer db.Close()
 
-	// TODO:
-	// store filename
-
 	tables := []string{
 		`CREATE TABLE IF NOT EXISTS image (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -3,26 +3,14 @@ package database
 import (
 	"database/sql"
 	"log"
-	"os"
 
-	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/config"
 	_ "github.com/mattn/go-sqlite3"
 )
 
 var db *sql.DB
 
-// public function for initializing the database
-func Init() {
-	if err := os.MkdirAll(config.General.DataDir, os.ModePerm); err != nil {
-		log.Fatal("Failed to create data directory:", err)
-	}
-
-	var err error
-	db, err = sql.Open("sqlite3", config.General.DataDir+"filelocations.db")
-	if err != nil {
-		log.Fatal("Failed to open database:", err)
-	}
-	defer db.Close()
+func Init(userDB *sql.DB) {
+	db = userDB
 
 	tables := []string{
 		`CREATE TABLE IF NOT EXISTS image (
@@ -61,20 +49,20 @@ func Insert(tableName, filename, filepath string) error {
 	return err
 }
 
-func GetPathByFilename(db *sql.DB, tableName, filename string) (string, error) {
+func GetPathByFilename(tableName, filename string) (string, error) {
 	query := "SELECT filepath FROM " + tableName + " WHERE filename = ?"
 	var filepath string
 	err := db.QueryRow(query, filename).Scan(&filepath)
 	return filepath, err
 }
 
-func DeleteRecordByFilename(db *sql.DB, tableName, filename string) error {
+func DeleteRecordByFilename(tableName, filename string) error {
 	query := "DELETE FROM " + tableName + " WHERE filename = ?"
 	_, err := db.Exec(query, filename)
 	return err
 }
 
-func ListAllFilenames(db *sql.DB, tableName string) ([]string, error) {
+func ListAllFilenames(tableName string) ([]string, error) {
 	query := "SELECT filename FROM " + tableName
 	rows, err := db.Query(query)
 	if err != nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -25,44 +25,73 @@ func Init() {
 	defer db.Close()
 
 	// TODO:
-	// need table for each type of thing (image, video, gifs, 3dmodels)
-	// store file location
 	// store filename
 
-	fileTypes := []string{"image", "video", "gif", "model"}
-	// iterates through the four file types and creates a table for each
-	// each table contains id and filepath
-	for i := 0; i < len(fileTypes); i++ {
-		statement, err := db.Prepare("CREATE TABLE IF NOT EXISTS " + fileTypes[i] + " (id INTEGER PRIMARY KEY, filepath TEXT)")
-		if err != nil {
-			log.Fatalf("Failed to prepare CREATE TABLE statement for '%s': %v", fileTypes[i], err)
-		}
-		_, err = statement.Exec()
-		if err != nil {
-			log.Fatalf("Failed to execute CREATE TABLE statement for '%s': %v", fileTypes[i], err)
-		}
-		statement, err = db.Prepare("INSERT INTO " + fileTypes[i] + " (filepath) VALUES (?)")
-		if err != nil {
-			log.Fatalf("Failed to prepare INSERT statement for '%s': %v", fileTypes[i], err)
-		}
-		_, err = statement.Exec("some filepath")
-		if err != nil {
-			log.Fatalf("Failed to execute INSERT statement for '%s': %v", fileTypes[i], err)
-		}
+	tables := []string{
+		`CREATE TABLE IF NOT EXISTS image (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			filename TEXT,
+			filepath TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS video (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			filename TEXT,
+			filepath TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS gif (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			filename TEXT,
+			filepath TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS model (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			filename TEXT,
+			filepath TEXT
+		)`,
+	}
 
-		rows, err := db.Query("SELECT id, filepath FROM " + fileTypes[i])
+	for _, tableQuery := range tables {
+		_, err := db.Exec(tableQuery)
 		if err != nil {
-			log.Fatalf("Failed to query SELECT statement for '%s': %v", fileTypes[i], err)
-		}
-
-		var id int
-		var filepath string
-
-		for rows.Next() {
-			if err := rows.Scan(&id, &filepath); err != nil {
-				log.Printf("Error scanning row: %v", err)
-				continue
-			}
+			log.Fatal("Error creating tables", err)
 		}
 	}
+}
+
+func Insert(tableName, filename, filepath string) error {
+	query := "INSERT INTO " + tableName + " (filename, filepath) VALUES (?, ?)"
+	_, err := db.Exec(query, filename, filepath)
+	return err
+}
+
+func GetPathByFilename(db *sql.DB, tableName, filename string) (string, error) {
+	query := "SELECT filepath FROM " + tableName + " WHERE filename = ?"
+	var filepath string
+	err := db.QueryRow(query, filename).Scan(&filepath)
+	return filepath, err
+}
+
+func DeleteRecordByFilename(db *sql.DB, tableName, filename string) error {
+	query := "DELETE FROM " + tableName + " WHERE filename = ?"
+	_, err := db.Exec(query, filename)
+	return err
+}
+
+func ListAllFilenames(db *sql.DB, tableName string) ([]string, error) {
+	query := "SELECT filename FROM " + tableName
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var filenames []string
+	for rows.Next() {
+		var filename string
+		if err := rows.Scan(&filename); err != nil {
+			return nil, err
+		}
+		filenames = append(filenames, filename)
+	}
+	return filenames, nil
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,61 +1,41 @@
 package database_test
 
 import (
-	"database/sql"
-	"fmt"
-	"os"
+	"log"
 
-	"strconv"
 	"testing"
 
 	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/config"
+	"github.com/METIL-HoloAI/HoloTable-Middleware/internal/database"
 	_ "github.com/mattn/go-sqlite3"
 )
 
 // public function for initializing the database
 func TestDatabaseInit(t *testing.T) {
 	config.LoadYaml()
-	if err := os.MkdirAll(config.General.DataDir, os.ModePerm); err != nil {
-		t.Fatal("Failed to create data directory:", err)
-	}
-	db, err := sql.Open("sqlite3", config.General.DataDir+"test.db")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
+	database.Init()
 
-	statement, err := db.Prepare("CREATE TABLE IF NOT EXISTS testdb (id INTEGER PRIMARY KEY, firstname TEXT, lastname TEXT)")
+	err := database.Insert("image", "test", "test")
 	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = statement.Exec()
-	if err != nil {
-		t.Fatal(err)
-	}
-	statement, err = db.Prepare("INSERT INTO testdb (firstname, lastname) VALUES (?, ?)")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = statement.Exec("Enrique", "Romero")
-	if err != nil {
-		t.Fatal(err)
+		t.Fatal("Failed to insert into image, ", err)
 	}
 
-	rows, err := db.Query("SELECT id, firstname, lastname FROM testdb")
+	path, err := database.GetPathByFilename("image", "test")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("Failed to get test back, ", err)
+	}
+	t.Log(path)
+
+	items, err := database.ListAllFilenames("image")
+	if err != nil {
+		t.Fatal("Failed to list all filenames in images, ", err)
+	}
+	for _, item := range items {
+		t.Log(item)
 	}
 
-	var id int
-	var firstname string
-	var lastname string
-
-	for rows.Next() {
-		err := rows.Scan(&id, &firstname, &lastname)
-		if err != nil {
-			t.Fatal(err)
-		}
-		fmt.Println(strconv.Itoa(id) + " : " + firstname + " " + lastname)
+	err = database.DeleteRecordByFilename("image", "test")
+	if err != nil {
+		log.Fatal("Failed to remove test record, ", err)
 	}
-
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,7 +1,9 @@
 package database_test
 
 import (
+	"database/sql"
 	"log"
+	"os"
 
 	"testing"
 
@@ -13,9 +15,20 @@ import (
 // public function for initializing the database
 func TestDatabaseInit(t *testing.T) {
 	config.LoadYaml()
-	database.Init()
 
-	err := database.Insert("image", "test", "test")
+	if err := os.MkdirAll(config.General.DataDir, os.ModePerm); err != nil {
+		t.Fatal("Failed to create data directory:", err)
+	}
+
+	db, err := sql.Open("sqlite3", config.General.DataDir+"test.db")
+	if err != nil {
+		t.Fatal("Failed to open database:", err)
+	}
+	defer db.Close()
+
+	database.Init(db)
+
+	err = database.Insert("image", "test", "test")
 	if err != nil {
 		t.Fatal("Failed to insert into image, ", err)
 	}


### PR DESCRIPTION
These changes add a way to add, view, and remove from the database. In order to accomplish this the following had to be changed:
- The database must be declared prior to calling Init. This is due to how the sql library handles opening the database. The database is only open for the duration of the function it is opened in, which is why opening the database had to be moved to main.
- Init now just sets up the general table structure, and has to be passed which database to initialize.
  - Note once the database is initialized, it is kept track within the database file and you don't need to pass database information to do a read/write/delete