### PR TITLE
Implement Config Refresh on Middleware Side

### DIFF
--- a/internal/endpoints/restapi/restapi.go
+++ b/internal/endpoints/restapi/restapi.go
@@ -135,6 +135,7 @@ func putYamlHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	config.LoadYaml()
 	w.WriteHeader(http.StatusOK)
 
 	_, err = w.Write([]byte("YAML updated"))


### PR DESCRIPTION
This one line change adds a call to LoadYaml() inside of the putYamlHandler function. 

This PR works in tandem with changes coming to the GUI repo. On the GUI repo, there will be a change added which fetch the keyword every time the user switches to the SpeechInput component.

**Why?**
The issue we were running into was that the configuration (including the **keyword**) is only loaded when the server starts via config.LoadYaml. Changing the file via the API from the frontend doesn't refresh the in-memory config.

To fix this, we added the config.LoadYaml() call after updating the file in putYamlHandler. 

**Result:**
Now when putYamlHandler is called from the frontend when the user submits a PUT call, configs are reloaded and the user can then fetch the new keyword every time they switch to the speech input component. This results in the keyword being properly updated on the SpeechInput component after being edited during the user's current session of the GUI.

https://github.com/user-attachments/assets/b6b03f4e-2e22-4707-9667-b7676479371b

